### PR TITLE
Dimensões do formulário e ícone home

### DIFF
--- a/hashtagfinder/src/index.js
+++ b/hashtagfinder/src/index.js
@@ -6,4 +6,5 @@ const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
+);


### PR DESCRIPTION
Correções realizadas: as dimensões do formulário estavam incorretas e o ícone home tinha sumido do do botão.